### PR TITLE
Update PyCharm Community to 2020.2

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -3,9 +3,9 @@
 # Contributor: David Keogh <davekeogh@archlinux.us>
 
 pkgname=pycharm-community-edition
-pkgver=2020.1.4
-_build=201.8743.11
-_gitcommit=260a7894571c469a79b33e8238f552c5d5ac467d
+pkgver=2020.2
+_build=202.6397.98
+_gitcommit=f0b3942b49880400994f62c064afd4ef909539eb
 pkgrel=1
 pkgdesc='Python IDE for Professional Developers'
 arch=(x86_64)


### PR DESCRIPTION
Hello, I've been using a locally-built version of PyCharm Community 2020.2 and thought I could save someone a bit of time looking up the `_build` & `_gitcommit` values.