### PR TITLE
Updated current location of ghc package

### DIFF
--- a/trunk/stack.install
+++ b/trunk/stack.install
@@ -1,4 +1,4 @@
 post_install() {
-  echo "You need to either 1) install latest stable ghc package from [extra] or 2) install ncurses5-compat-libs from AUR for the prebuilt binaries installed by stack to work."
+  echo "You need to either 1) install latest stable ghc package from [community] or 2) install ncurses5-compat-libs from AUR for the prebuilt binaries installed by stack to work."
 }
 


### PR DESCRIPTION
During installation of `stack` pacman says that `ghc` could be installed from [extra](https://www.archlinux.org/packages/?repo=Extra&q=ghc) repo, although it's actually in [community](https://www.archlinux.org/packages/?repo=Community&q=ghc). It's not that important, but still an inaccuracy.