### PR TITLE
Add `libappindicator-gtk3` to `discord` optdepends

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -9,7 +9,8 @@ arch=('x86_64')
 url='https://discordapp.com'
 license=('custom')
 depends=('libnotify' 'libxss' 'nspr' 'nss' 'gtk3')
-optdepends=('libpulse: Pulseaudio support'
+optdepends=('libappindicator-gtk3: Tray icon support'
+            'libpulse: Pulseaudio support'
             'xdg-utils: Open files')
 source=("https://dl.discordapp.net/apps/linux/$pkgver/$pkgname-$pkgver.tar.gz"
         'LICENSE.html::https://discordapp.com/terms'


### PR DESCRIPTION
As mentioned in the ArchWiki https://wiki.archlinux.org/title/Discord#GNOME_top_bar_icon