### PR TITLE
Add gcc-fortran as optdepends

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -16,7 +16,8 @@ optdepends=('texinfo: for help-support in octave'
             'gnuplot: alternative plotting'
             'portaudio: audio support'
             'java-runtime: java support'
-            'fltk: FLTK GUI')
+            'fltk: FLTK GUI'
+            'gcc-fortran: Package building from forge')
 source=(https://ftp.gnu.org/gnu/octave/octave-$pkgver.tar.gz{,.sig})
 options=('!emptydirs')
 validpgpkeys=('DBD9C84E39FE1AAE99F04446B05F05B75D36644B')  # John W. Eaton


### PR DESCRIPTION
During the build of the forge Package  it is assumed that gcc-fortran  is installed, it will nice to have that as optdepends.