### PR TITLE
Add creation of zerotier-one user using systemd-sysusers so that the daemon can drop root privs

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -32,5 +32,6 @@ check() {
 package() {
   cd ZeroTierOne-$pkgver
   make DESTDIR="$pkgdir" install
+  install -Dm644 sysusers.conf "$pkgdir/usr/lib/sysusers.d/$pkgname.conf"
   install -Dm644 debian/zerotier-one.service "$pkgdir"/usr/lib/systemd/system/zerotier-one.service
 }

--- a/trunk/sysusers.conf
+++ b/trunk/sysusers.conf
@@ -1,0 +1,1 @@
+u zerotier-one - "ZeroTier User" /var/lib/zerotier-one /usr/bin/nologin


### PR DESCRIPTION
If zerotier-one finds a user named "zerotier-one", it will drop root privileges as soon as it can and run as that user, which is obviously far more desirable than running as root.

The upstream ZeroTier RPM spec file creates the user by default, and so does the Debian deb package. This is clearly the intent of the ZT developers and the Arch package should follow the same convention.