### PR TITLE
Update python-configargparse to v1.4.1

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -1,18 +1,18 @@
 # Maintainer: Felix Yan <felixonmars@archlinux.org>
 
 pkgname=python-configargparse
-pkgver=1.2.3
-pkgrel=3
+pkgver=1.4.1
+pkgrel=1
 pkgdesc='A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables'
 arch=('any')
-url='https://github.com/zorro3/ConfigArgParse'
+url='https://github.com/bw2/ConfigArgParse'
 license=('MIT')
 depends=('python')
 makedepends=('python-setuptools')
 checkdepends=('python-tests' 'python-yaml')
 optdepends=('python-yaml: for YAML support')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/bw2/ConfigArgParse/archive/$pkgver.tar.gz")
-sha512sums=('bfa8f9ca8ab5c6d4cdf2a7e7c577c99fafdf7f743c81057bebbb6045c45de2cdbf5d738f7765e5dcac5a45baa92e2a8bc7ad3879776b9cf4862e3da94e78c4cc')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/bw2/ConfigArgParse/archive/v$pkgver.tar.gz")
+sha512sums=('304d5981c5685188edb22a63966d25a8943e4c443f2aefc323492f141885f50657e9f9200514df65683f1e13e64173d4def80cdbebcff941c3ee66ff4af0cbd4')
 
 build() {
   cd ConfigArgParse-$pkgver
@@ -21,7 +21,7 @@ build() {
 
 check() {
   cd ConfigArgParse-$pkgver
-  python setup.py test || echo 'Ignoring TestWrappingMetavar failure'
+  python setup.py test
 }
 
 package() {


### PR DESCRIPTION
I use python-configargparse in most of my python scripts and this contains required fixes against null value errors with the yaml parser.