### PR TITLE
Allow ccze color scheme customization

### DIFF
--- a/ccze/trunk/PKGBUILD
+++ b/ccze/trunk/PKGBUILD
@@ -2,10 +2,11 @@
 
 pkgname=ccze
 pkgver=0.2.1
-pkgrel=11
+pkgrel=12
 pkgdesc="Robust and modular log colorizer with many plugins"
 arch=('x86_64')
 url="http://freshmeat.net/projects/ccze/"
+backup=('etc/cczerc')
 license=('GPL')
 depends=('ncurses' 'pcre')
 makedepends=('patch')
@@ -31,4 +32,10 @@ package() {
   cd "${srcdir}"/$pkgname-$pkgver
 
   make DESTDIR="${pkgdir}" install
+  
+  # add ccze-dump
+   install -Dm 755 -t "${pkgdir}"/usr/bin src/ccze-dump
+  # add cczerc
+  "${pkgdir}"/usr/bin/ccze-dump > "${srcdir}"/cczerc
+  install -Dm 644 -t "${pkgdir}"/etc "${srcdir}"/cczerc
 }


### PR DESCRIPTION
Add ccze-dump and /etc/cczerc to allow user customization of ccze's color scheme. See https://bugs.archlinux.org/task/71267.