### PR TITLE
chore(waybar): bump to 0.9.8 release

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Maxim Baz <$pkgname at maximbaz dot com>
 
 pkgname=waybar
-pkgver=0.9.7
+pkgver=0.9.8
 pkgrel=5
 pkgdesc='Highly customizable Wayland bar for Sway and Wlroots based compositors'
 arch=('x86_64')
@@ -35,16 +35,10 @@ optdepends=(
 )
 source=(
     "$pkgname-$pkgver.tar.gz::https://github.com/Alexays/Waybar/archive/$pkgver.tar.gz"
-    "https://github.com/Alexays/Waybar/pull/1144.patch"
 )
-sha256sums=('0d23573e0f6ce6e3f3eb4d1d7313848b924429268f3becd81649a391ae7703e7'
-            '24e27ce50647cec5ad4d5e667c22b538d404fa865e8aba2a0dadac2166502a95')
-
-prepare() {
-    cd "Waybar-$pkgver"
-    # libfmt >=8.0.0 compatibility, merged upstream but not yet released.
-    patch -Np1 -i ../1144.patch
-}
+sha256sums=(
+    '3f067c484aaee3e7d8ded382e72c280a92913b0c4e8a20d0ac9afdf8baf19405'
+)
 
 build() {
     cd "Waybar-$pkgver"


### PR DESCRIPTION
patch no longer necessary