### PR TITLE
Update to 4.0.3

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgbase=rssguard
 pkgname=(rssguard{,-nowebengine})
-pkgver=4.0.2
+pkgver=4.0.3
 pkgrel=1
 pkgdesc='Simple (yet powerful) Qt5 feed reader'
 arch=('x86_64')


### PR DESCRIPTION
Five days ago RssGuard has updated to 4.0.3, an important bug fix.