### PR TITLE
Build with icu support

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -11,12 +11,12 @@ pkgdesc="Free implementation of the Remote Desktop Protocol (RDP)"
 arch=('x86_64')
 url="https://www.freerdp.com/"
 license=('Apache')
-depends=('dbus-glib' 'glibc' 'gstreamer' 'gst-plugins-base-libs' 'libcups'
+depends=('dbus-glib' 'glibc' 'gstreamer' 'gst-plugins-base-libs' 'libcups' 
 'libgssglue' 'libx11' 'libxcursor' 'libxext' 'libxdamage' 'libxfixes'
 'libxkbcommon' 'libxi' 'libxinerama' 'libxkbfile' 'libxrandr' 'libxrender'
 'libxtst' 'openssl' 'pcsclite' 'wayland')
 makedepends=('alsa-lib' 'cmake' 'docbook-xsl' 'ffmpeg' 'krb5' 'libjpeg-turbo'
-'libpulse' 'libusb' 'pam' 'systemd-libs' 'xmlto' 'xorgproto')
+'libpulse' 'libusb' 'pam' 'systemd-libs' 'xmlto' 'xorgproto' 'icu')
 provides=('libfreerdp2.so' 'libfreerdp-client2.so' 'libfreerdp-server2'
 'libfreerdp-shadow2.so' 'libfreerdp-shadow-subsystem2.so' 'libwinpr2.so'
 'libwinpr-tools2.so' 'libuwac0.so')
@@ -41,6 +41,7 @@ build() {
         -DCMAKE_INSTALL_LIBDIR='lib' \
         -DCMAKE_BUILD_TYPE='None' \
         -DPROXY_PLUGINDIR='/usr/lib/freerdp2/server/proxy/plugins' \
+        -DWITH_ICU=ON \
         -DWITH_DSP_FFMPEG=ON \
         -DWITH_FFMPEG=ON \
         -DWITH_PULSE=ON \


### PR DESCRIPTION
See upstream issue https://github.com/FreeRDP/FreeRDP/issues/7363

FreeRDP does its own character conversions when icu is not available, but it doesn't support WCHAR and other have other potential issues.

I'm not sure icu should be added in makedepends or only in depends, sorry I'm not an expert.
icu is needed at compile and at runtime.

Thanks!