### PR TITLE
Updated to 1.6.2

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -6,8 +6,7 @@
 
 pkgname=nim
 _pkgname=Nim
-pkgver=1.4.8
-_csourcesver=0.20.0
+pkgver=1.6.2
 pkgrel=1
 pkgdesc='Imperative, multi-paradigm, compiled programming language'
 url='https://nim-lang.org/'
@@ -23,16 +22,12 @@ backup=(
   etc/nim/nimdoc.tex.cfg
   etc/nim/rename.rules.cfg
 )
-source=(https://github.com/nim-lang/Nim/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
-        https://github.com/nim-lang/csources/archive/v${_csourcesver}/csources-${_csourcesver}.tar.gz)
-sha256sums=('8a687beb30670dc4eadcfefd1198d4238af283dc716438ac2342a7d65e07d9e9'
-            '5e6fd15d90df1a8cb7614c4ffc70aa8c4198cd854d7742016202b96dd0228d3c')
-b2sums=('7059d73cb7e2333911ed0ae1e55398255cfc32fd8732af80657343da9ba977fbdd6753737c7509aac4e7f9160cb9e3e4415f45770ee1cac15aeb780315346010'
-        'a1c026aa4ecd676d938d00f13f749b7c21094f87de98055ef0002bc96cafb81a780b7d82adfa3927bb32b0eb52c8047ac2b2c98d0ab3b9af0dd8c8ebeffad50b')
+source=(https://github.com/nim-lang/Nim/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz)
+sha256sums=('13bac639faa459c9e437374acdd26dbe74271713b9f61324758812e40f73d09d')
+b2sums=('3d12a0ceb2edd090bd63fb10de2208978075283b8f643fe5f71941dbaa8b92bd65348cf3efaf25305a4dda928b7daacd3657e110b9416dfc36523c8d823eeb3b')
 
 prepare() {
   cd ${_pkgname}-${pkgver}
-  mv ../csources-${_csourcesver} csources
   rm bin/empty.txt
   for nimcfg in {compiler,config}/nim.cfg; do
     echo "gcc.options.always %= \"\${gcc.options.always} ${CFLAGS:-} ${CPPFLAGS}\"" >> "${nimcfg}"
@@ -44,13 +39,8 @@ build() {
   cd ${_pkgname}-${pkgver}
   export PATH="${srcdir}/${_pkgname}-${pkgver}/bin:${PATH}"
 
-  echo "Building nim"
-  (cd csources
-    sh build.sh
-  )
-  echo "Building koch"
-  nim c -d:release koch
-  ./koch boot -d:release -d:nativeStacktrace -d:useGnuReadline
+  echo "Building all"
+  sh build_all.sh
 
   echo "Building libs"
   (cd lib
@@ -58,10 +48,10 @@ build() {
   )
 
   echo "Building tools"
-  ./koch tools
   (cd tools
     nim c -d:release nimgrep.nim
   )
+
   echo "Building nimsuggest"
   nim c -d:release nimsuggest/nimsuggest.nim
 }
@@ -89,7 +79,7 @@ package() {
   cp -a "${pkgdir}/usr/lib/nim/"*.h "${pkgdir}/usr/include"
 
   install -d "${pkgdir}/usr/share/nim/doc"
-  cp -a examples doc/* "${pkgdir}/usr/share/nim/doc"
+  cp -a doc/* "${pkgdir}/usr/share/nim/doc"
 
   install -Dm 644 copying.txt -t "${pkgdir}/usr/share/licenses/${pkgname}"
 


### PR DESCRIPTION
Nim's building changed a bit since 1.6:
- csources is now handled by nim itself
- the folder examples was removed (I did not find the files from 1.4.8 in the new version 1.6)