### PR TITLE
Making use of sub:init npm function for the bitwarden-cli

### DIFF
--- a/bitwarden-cli/repos/community-any/PKGBUILD
+++ b/bitwarden-cli/repos/community-any/PKGBUILD
@@ -11,17 +11,12 @@ license=('GPL3')
 depends=('nodejs')
 makedepends=('git' 'npm' 'modclean')
 options=(!emptydirs)
-source=(bitwarden-cli::git+https://github.com/bitwarden/cli.git#tag=v${pkgver}
-        bitwarden-jslib::git+https://github.com/bitwarden/jslib.git)
-sha512sums=('SKIP'
-            'SKIP')
+source=(bitwarden-cli::git+https://github.com/bitwarden/cli.git#tag=v${pkgver})
+sha512sums=('SKIP')
 
 prepare() {
 	cd bitwarden-cli
-	# Link jslib
-	git submodule init
-	git config submodule.jslib.url "$srcdir/bitwarden-jslib"
-	git submodule update
+	npm run sub:init
 }
 
 build() {
@@ -48,7 +43,5 @@ package() {
 	install -vDm644 _bw -t "${pkgdir}/usr/share/zsh/site-functions"
 
 	# cleanup
-	sed -e "s|${srcdir}|/|" -i "$pkgdir"/usr/lib/node_modules/@bitwarden/cli/package.json
-	find "$pkgdir"/usr/lib/node_modules -name 'package.json' -exec sed -e "s|${srcdir}||" -i {} \;
 	modclean --path "$pkgdir"/usr/lib -r -a "*.ts,.bin,.github,.vscode,bin.js" --ignore='license'
 }


### PR DESCRIPTION
The npm already has a function which imports the submodule jslib . So it is not required to pull the git repo seperately and then performing a cleanup.