### PR TITLE
Move Java dependency to JRE 11

### DIFF
--- a/repos/community-any/PKGBUILD
+++ b/repos/community-any/PKGBUILD
@@ -10,7 +10,7 @@ pkgdesc='Extendable continuous integration server (latest)'
 arch=('any')
 url='https://jenkins.io'
 license=('MIT')
-depends=('java-runtime=8' 'ttf-dejavu')
+depends=('jre11-openjdk' 'ttf-dejavu')
 provides=('jenkins-ci')
 conflicts=('jenkins-ci')
 replaces=('jenkins-ci')


### PR DESCRIPTION
Weekly Jenkins versions will only support JDK 11 from June 2022, and LTS versions from September 2022.