### PR TITLE
020-linux518.patch

### DIFF
--- a/virtualbox/trunk/020-linux518.patch
+++ b/virtualbox/trunk/020-linux518.patch
@@ -245,15 +245,17 @@ Index: src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
 ===================================================================
 --- trunk/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	(revision 151556)
 +++ trunk/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c	(working copy)
-@@ -2311,7 +2311,13 @@
+@@ -2310,8 +2310,15 @@
+             {
                  vboxNetFltDumpPacket(pSG, true, "host", (fDst & INTNETTRUNKDIR_WIRE) ? 0 : 1);
                  Log6(("vboxNetFltPortOsXmit: pBuf->cb dump:\n%.*Rhxd\n", sizeof(pBuf->cb), pBuf->cb));
-                 Log6(("vboxNetFltPortOsXmit: netif_rx_ni(%p)\n", pBuf));
 +#if RTLNX_VER_MIN(5,18,0)
+                 Log6(("vboxNetFltPortOsXmit: netif_rx_ni(%p)\n", pBuf));
 +                local_bh_disable();
 +                err = netif_rx(pBuf);
 +                local_bh_enable();
 +#else
++                Log6(("vboxNetFltPortOsXmit: netif_rx(%p)\n", pBuf));
                  err = netif_rx_ni(pBuf);
 +#endif
                  if (err)

--- a/virtualbox/trunk/PKGBUILD
+++ b/virtualbox/trunk/PKGBUILD
@@ -103,7 +103,7 @@ sha256sums=('9c3ce1829432e5b8374f950698587038f45fb0492147dc200e59edb9bb75eb49'
             '5aac692909a0a0ec56b08bdece9e42cf7463abdca9da2f990d441ff463be6a99'
             'cac5a573e9ed5aafb2f469c2e6fffb8cd4f389bbadba5a968c9f65be7a72fee3'
             '25066d566042a3b3d6dee805fe783ca07fd3c3671a098db2b5f09aeb07624cd2'
-            '3ea54e5a747086c388d078b12117cdb640a937e3147b71031abcff2497ff1e97')
+            'fcb02ee903dce29dad907aeb24beb8f809c9472172de029c99b9661f1308bd3a')
 
 prepare() {
     cd "VirtualBox-$pkgver"


### PR DESCRIPTION
fix
There is not netif_rx_ni at linux518.