### PR TITLE
Packages/sweethome3d fix when java 18 is installed and update to 7.0

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -6,8 +6,8 @@
 # Contributor: Archan Paul <paul.archan@gmail.com>
 
 pkgname=sweethome3d
-pkgver=6.6
-pkgrel=4
+pkgver=7.0
+pkgrel=1
 pkgdesc="An interior design application to draw the plan of your house in a 3D environment"
 arch=('x86_64')
 url="http://www.sweethome3d.com/"

--- a/trunk/sweethome3d.sh
+++ b/trunk/sweethome3d.sh
@@ -30,7 +30,7 @@ JAVA_VERSION="$(${JAVA_EXEC} -version 2>&1 | head -1 | cut -d' ' -f 3 | tr -d '"
 if [ $(vercmp "${JAVA_VERSION}" "17") -gt 0 ]
 then
   echo "Warning: Sweethome 3D actually is not compatible with Java version > 16"
-  _PREVIOUS_JAVA_VERSION="$(archlinux-java status | tail -n +2 | sort | cut -d ' ' -f 3 | sort -nr -k 2 -t '-' | grep -vE '17-' -m 1)"
+  _PREVIOUS_JAVA_VERSION="$(archlinux-java status | tail -n +2 | sort | cut -d ' ' -f 3 | sort -nr -k 2 -t '-' | grep -vE '(1[789]|[2-9][0-9])-' -m 1)"
   if [ -z "${_PREVIOUS_JAVA_VERSION}" ]
   then
     echo "No others Java version are available, please install a Java version < 17"


### PR DESCRIPTION
Fix start script to fallback to smaller version than java-17, so it ignores java-18 and any new version released in the future

Upgrade to latest version 7.0