### PR TITLE
Update sweethome3d to 7.0 and fix start script when java 18 is installed

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -6,8 +6,8 @@
 # Contributor: Archan Paul <paul.archan@gmail.com>
 
 pkgname=sweethome3d
-pkgver=6.6
-pkgrel=4
+pkgver=7.0
+pkgrel=1
 pkgdesc="An interior design application to draw the plan of your house in a 3D environment"
 arch=('x86_64')
 url="http://www.sweethome3d.com/"

--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -18,8 +18,8 @@ source=("SweetHome3D-${pkgver}-src.zip"::"https://downloads.sourceforge.net/${pk
         "${pkgname}.sh"
         "${pkgname}.desktop"
         "${pkgname}.xml")
-sha256sums=('0a7557a66a1d9b2a1976a9adece811cb3b8b7838643e1ac04bf0a574533c490b'
-            '6b3ef93a004d05ea083953d651e151af5491f5ca91e00dfd4ec3f0e4e1c87782'
+sha256sums=('af0d2c89605f53056a199685dba221dc13fcff008be79bf3a0463e74266b8403'
+            '1b11d87377103f000e8cca6c3e9b8e2dd0492642adaa80187a556a8a0c933443'
             '5eea3337d956d773b05ddef69fe9d34b940ff550370dc92bf307f1b9a3957f9e'
             'ec0ad1a0671f708af68ced46bec1f4ab377e24ca1a0a9984867ee5fe484f57c5')
 install="${pkgname}.install"

--- a/trunk/sweethome3d.sh
+++ b/trunk/sweethome3d.sh
@@ -30,7 +30,7 @@ JAVA_VERSION="$(${JAVA_EXEC} -version 2>&1 | head -1 | cut -d' ' -f 3 | tr -d '"
 if [ $(vercmp "${JAVA_VERSION}" "17") -gt 0 ]
 then
   echo "Warning: Sweethome 3D actually is not compatible with Java version > 16"
-  _PREVIOUS_JAVA_VERSION="$(archlinux-java status | tail -n +2 | sort | cut -d ' ' -f 3 | sort -nr -k 2 -t '-' | grep -vE '17-' -m 1)"
+  _PREVIOUS_JAVA_VERSION="$(archlinux-java status | tail -n +2 | sort | cut -d ' ' -f 3 | sort -nr -k 2 -t '-' | grep -vE '(1[789]|[2-9][0-9])-' -m 1)"
   if [ -z "${_PREVIOUS_JAVA_VERSION}" ]
   then
     echo "No others Java version are available, please install a Java version < 17"


### PR DESCRIPTION
Fix start script to fallback to smaller version than java-17, so it ignores java-18 and any new version released in the future

Upgrade to latest version 7.0