### PR TITLE
Increases the amount of allocated memory

### DIFF
--- a/trunk/fc.sh
+++ b/trunk/fc.sh
@@ -2,4 +2,4 @@
 
 FC_PATH=/usr/share/java/freecol
 
-java -Xmx512M -jar $FC_PATH/FreeCol.jar "$@" --freecol-data $FC_PATH/data --no-intro
+java -Xmx2G -jar $FC_PATH/FreeCol.jar "$@" --freecol-data $FC_PATH/data --no-intro


### PR DESCRIPTION
FreeCol now requires at least 2GB of memory:
https://sourceforge.net/p/freecol/bugs/3304/

You might also want to consider removing the "--no-intro" option, as a couple of known bugs related to the intro movie has been fixed. That's not included in this PR, however, since I'm not able to test the change on an Arch system right now.