### PR TITLE
Update nushell PKGBUILD to add dataframes back in.

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -34,12 +34,12 @@ prepare() {
 
 build() {
   cd "$pkgname"
-  cargo build --release --frozen --workspace --features=extra
+  cargo build --release --frozen --workspace --features=extra,dataframe
 }
 
 check() {
   cd "$pkgname"
-  cargo test --frozen --workspace --features=extra
+  cargo test --frozen --workspace --features=extra,dataframe
 }
 
 package() {


### PR DESCRIPTION
In the latest 0.72 release of nushell, dataframes were removed from 'extra'. To add this functionality back in you need to add 'dataframe' to the cargo build and cargo test commands. I've amended lines 37 and 42 to do this.