### PR TITLE
Switch to new configure script

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=xmake
 pkgver=2.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc='A cross-platform build utility based on Lua'
 arch=(x86_64 i686 aarch64)
 url="https://github.com/xmake-io/$pkgname"
@@ -19,10 +19,11 @@ sha256sums=('d490ff8825fa53fe5abfb549310cb54a2dfef1ebd3f82e24548483772994e06a')
 
 build() {
 	# cd "$_archive"
+	./configure
 	make build
 }
 
 package() {
 	# cd "$_archive"
-	make install DESTDIR="$pkgdir" PREFIX="/usr"
+    	make install PREFIX="${pkgdir}/usr"
 }


### PR DESCRIPTION
Since version 2.7.4, xmake has used a new configure script to build itself. The old makefile file will be removed in the next release.