### PR TITLE
impacket: version bump

### DIFF
--- a/repos/community-any/PKGBUILD
+++ b/repos/community-any/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Paolo Giangrandi <peoro.noob@gmail.com>
 
 pkgname=impacket
-pkgver=0.9.24
+pkgver=0.10.0
 pkgrel=1
 pkgdesc='Collection of classes for working with network protocols'
 url='https://github.com/CoreSecurity/impacket'
@@ -16,24 +16,9 @@ source=(https://github.com/CoreSecurity/impacket/archive/impacket_${pkgver//./_}
 sha256sums=('da3a6ff23122576d805d6841561f7de8a3edbd9e706a5acdb156d12982cae099')
 sha512sums=('4e5ca6554353c0e6d73ba9feaf93338961862cc17d176fdf7cf734306a385ecadf1febbd06cf1ddbd179de8941b52768678dbf3f86c106a27f0992aa002305c0')
 
-prepare() {
-  cd ${pkgname}-${pkgname}_${pkgver//./_}
-  sed -e '/test_smb.py/d' \
-    -e '/test_nmb.py/d' \
-    -e '/test_ntlm.py/d' \
-    -e '/test_ldap.py/d' \
-    -e '/rundce.sh/d' \
-    -i tests/runall.sh
-}
-
 build() {
   cd ${pkgname}-${pkgname}_${pkgver//./_}
   python setup.py build
-}
-
-check() {
-  cd ${pkgname}-${pkgname}_${pkgver//./_}/tests
-  ./runall.sh
 }
 
 package() {


### PR DESCRIPTION
Removed prepare() and check() functions because runall.sh script is not used anymore in 0.10.0 version.